### PR TITLE
Updated instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ git clone https://github.com/jeffkinnison/tesserae-frontend  # clone frontend
 cd tesserae-frontend
 npm install     # install frontend dependencies
 # change .env file so that REACT_APP_REST_API_URL is set to "http://localhost:4040"
+# also in the .env file, set REACT_APP_MODE to "ADMIN"
 # change package.json so that "homepage" is set to "./"
 npm run build   # build frontend
 cp -r build ../electron-tesserae/frontend    # bundle built frontend

--- a/package.json
+++ b/package.json
@@ -58,17 +58,17 @@
   "license": "ISC",
   "dependencies": {
     "gunzip-maybe": "^1.4.2",
-    "ini": "^1.3.5",
+    "ini": "^1.3.8",
     "mkdirp": "^1.0.4",
-    "mongodb": "^3.5.7",
+    "mongodb": "^3.6.3",
     "ps-tree": "^1.2.0",
-    "tar-fs": "^2.1.0",
+    "tar-fs": "^2.1.1",
     "yauzl": "^2.10.0"
   },
   "devDependencies": {
     "electron": "^9.1.2",
     "electron-builder": "^22.8.0",
     "eslint": "^7.5.0",
-    "shx": "^0.3.2"
+    "shx": "^0.3.3"
   }
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 PyInstaller>=3.6
-git+https://github.com/tesserae/tesserae-v5.git#egg=tesserae
 git+https://github.com/tesserae/apitess.git#egg=apitess


### PR DESCRIPTION
Pip complained about dependency problems between tesserae and apitess.
Since apitess installs tesserae as a dependency, I took tesserae out of
requirements.txt.

We'll also be wanting to expose admin privileges on the standalone
version.